### PR TITLE
fix verifyingContract to be a valid evm hex address (using `cosmos` as hex address)

### DIFF
--- a/ethereum/eip712/domain.go
+++ b/ethereum/eip712/domain.go
@@ -16,19 +16,22 @@
 package eip712
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
 )
 
 // createEIP712Domain creates the typed data domain for the given chainID.
 func createEIP712Domain(chainID uint64) apitypes.TypedDataDomain {
+	contractStr := "cosmos"
+	contractAddr := common.BytesToAddress([]byte(contractStr))
 	domain := apitypes.TypedDataDomain{
 		Name:              "Carbon",
 		Version:           "1.0.0",
 		ChainId:           math.NewHexOrDecimal256(int64(chainID)),
-		VerifyingContract: "cosmos",
+		VerifyingContract: contractAddr.Hex(),
 		Salt:              "1",
 	}
-
+	
 	return domain
 }


### PR DESCRIPTION
<img width="701" alt="image" src="https://github.com/user-attachments/assets/b7266d43-0c8f-4ba7-878c-805432763b3c">

MetaMask (currently only the extension) has added a new validation that requires the verifyingContract field in the EIP-712 JSON to be a valid EVM address. This change is causing issues because our verifyingContract is set to 'cosmos', preventing users from submitting transactions on Carbon via MetaMask.

To resolve this, we need to update verifyingContract to any valid hex address, but this will require a backend upgrade.

below is an issue created by another team which is facing the same issue:

https://github.com/MetaMask/metamask-extension/issues/26980

this is prob the quickest fix cos not sure when metamask team will update

the hex address can be anything, just need to follow the spec.


relevant portion of the code in metamask extension source code:

<img width="580" alt="image" src="https://github.com/user-attachments/assets/87622aa9-5b63-4f29-8c4c-473733a72483">


Edit: We have decided to go ahead with the hex representation of 'comsos' as the hex address




